### PR TITLE
Bug: fixed link from 404 to link to 'https://www.operationcode.org/join'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ This app will track the interaction of exercise and/or meditation on PTSD sympto
 ### *Version 1* (current) is a mood tracker.
 
 
-Find us on the [Operation Code](www.operationcode.org/join) Slack Team , channel #on-belay.
+Find us on the [Operation Code](https://www.operationcode.org/join) Slack Team , channel #on-belay.
 


### PR DESCRIPTION
I checked it on my repo a few times and it works. But please double check. 
Thanks and regards
Chad H. Glaser